### PR TITLE
Add gulp-gh-pages util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 node_modules
 css/main.css
 css/maps/main.css.map
+.publish

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -4,6 +4,7 @@ var sass        = require('gulp-sass');
 var prefix      = require('gulp-autoprefixer');
 var cp          = require('child_process');
 var sourcemaps = require('gulp-sourcemaps');
+var ghPages = require('gulp-gh-pages');
 
 var messages = {
     jekyllBuild: '<span style="color: grey">Running:</span> $ jekyll build'
@@ -67,3 +68,11 @@ gulp.task('watch', function () {
  * compile the jekyll site, launch BrowserSync & watch files.
  */
 gulp.task('default', ['browser-sync', 'watch']);
+
+/**
+ * Deploy to gh-pages branch to push to Github Pages instance
+ */
+gulp.task('deploy', function() {
+  return gulp.src('./_site/**/*')
+    .pipe(ghPages());
+});

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,6 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ "css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 </head>

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "gulp-sourcemaps": "^1.6.0",
     "npm": "^3.5.3",
     "vanilla-framework": "0.0.60"
+  },
+  "devDependencies": {
+    "gulp-gh-pages": "^0.5.4"
   }
 }


### PR DESCRIPTION
## Done

This allows a quick and easy deploy to gh-pages branch from the `_site` folder using the command `gulp deploy`.

The gh-pages branch is relative to the repository.

## QA

Fork this repo; run `gulp` to build out all site assets, then run `gulp deploy`

A demo should now be running at;

`http://YOUR-GITHUB-USERNAME.github.io/cloud-init/`
