### PR TITLE
Use vanilla framework util for vertical centering

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -18,7 +18,7 @@
     padding: 2rem 3rem;
 
     @media only screen and (min-width: $breakpoint-medium) {
-      min-height: 250px;
+      min-height: 15.625rem; // 250px
     }
   }
 }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -14,14 +14,3 @@
 'footer',
 'hero',
 'media-unit';
-
-@media only screen and (min-width: $breakpoint-medium) {
-
-  .flex-wrap {
-    display: flex;
-
-    > .four-col {
-      display: flex;
-    }
-  }
-}

--- a/index.html
+++ b/index.html
@@ -117,35 +117,29 @@ layout: default
   <section class="row source-code">
     <h2>Source Code</h2>
 
-    <div class="flex-wrap">
-
-      <div class="four-col">
-        <div class="box">
+      <div class="equal-height">
+        <div class="four-col box">
           <img class="box__img" src="https://assets.ubuntu.com/v1/087d7bb9-image-project-bazaar.png" alt="Baazar logo">
           <h3>Baazar</h3>
           <p>Browser and branch from Bazaar.</p>
           <a class="external box__link" href="https://code.launchpad.net/cloud-init">Baazar repository</a>
         </div>
-      </div>
 
-      <div class="four-col">
-        <div class="box">
+        <div class="four-col box">
           <img class="box__img" src="https://assets.ubuntu.com/v1/0fdf0020-github.png" alt="Github logo">
           <h3>Github</h3>
           <p>Browse, branch, fork or clone from Github.</p>
           <a class="external box__link" href="https://github.com/openstack/cloud-init">Github repository</a>
         </div>
-      </div>
 
-      <div class="four-col last-col">
-        <div class="box">
+        <div class="four-col last-col box">
           <img class="box__img" src="https://assets.ubuntu.com/v1/4cd0df1c-picto-download-orange.svg" alt="Download logo">
           <h3>Download</h3>
           <p>Download the offically released archives.</p>
           <a class="external box__link" href="https://launchpad.net/cloud-init/+download">Download project files</a>
         </div>
       </div>
-    </div>
+
   </section>
 
   <!-- Public Cloud Examples -->
@@ -188,36 +182,30 @@ layout: default
   </section>
 
   <!-- Support channels -->
-  <section class="row">
+  <section class="row support">
 
-    <div class="twelve-col">
-
+    <div class="eight-col">
       <h2>Need support?</h2>
-      <div class="flex-wrap">
-        <div class="four-col">
-          <div class="box">
-            <h3>
-              <a class="external" href="https://bugs.launchpad.net/cloud-init/+filebug">Report a bug</a>
-            </h3>
-            <p>Help us improve the software by flagging bugs and issues you find.</p>
-          </div>
-        </div>
-        <div class="four-col">
-          <div class="box">
-            <h3>
-              <a class="external" href="http://pingx.net/freenode/cloud-init">Chat on freenode</a>
-            </h3>
-            <p>We have an active IRC community &mdash; get involved!</p>
-          </div>
-        </div>
-        <div class="four-col last-col">
-          <div class="box">
-            <h3>
-              <a class="external" href="http://cloudinit.readthedocs.org/">Read the docs</a>
-            </h3>
-            <p>Always read the manual &mdash; perhaps your question has already be answered?</p>
-          </div>
-        </div>
+    </div>
+
+    <div class="equal-height">
+      <div class="four-col box">
+        <h3>
+          <a class="external" href="https://bugs.launchpad.net/cloud-init/+filebug">Report a bug</a>
+        </h3>
+        <p>Help us improve the software by flagging bugs and issues you find.</p>
+      </div>
+      <div class="four-col box">
+        <h3>
+          <a class="external" href="http://pingx.net/freenode/cloud-init">Chat on freenode</a>
+        </h3>
+        <p>We have an active IRC community &mdash; get involved!</p>
+      </div>
+      <div class="four-col last-col box">
+        <h3>
+          <a class="external" href="http://cloudinit.readthedocs.org/">Read the docs</a>
+        </h3>
+        <p>Always read the manual &mdash; perhaps your question has already be answered?</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Removed manual override for equal height boxes and utilised Vanilla Framework util instead.

## QA

Run code - boxes in "Source code" section and "Need  support" should be of equal height on screens with a width greater than 768px.
