### PR TITLE
Correct partner link / encode dashes / add deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ To fire up the project, you should then run;
 
 `http://localhost:3000/`
 
+## Deploy to Github Pages
+
+To deploy to Github Pages under your local Github username, please run;
+
+`gulp deploy`
+
+You should then be able to view the site at: `http://YOUR-GITHUB-USERNAME.github.io/cloud-init`
+
 ## Licence
 
 Code licensed [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd.](http://www.canonical.com/).

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ layout: default
         </li>
       </ul>
       <p class="align-center">
-        <a href="http://partners.ubuntu.com/programmes/public-cloud" class="external">See our other Ubuntu public cloud partners</a>
+        <a href="http://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" class="external">See our other Ubuntu public cloud partners</a>
       </p>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ layout: default
       <p>While cloud-init started life in Ubuntu, it is now available for most
         major linux and FreeBSD operating systems. For cloud image providers,
         then cloud-init handles many of the differences between cloud vendors
-        automatically -- for example, the official Ubuntu cloud images are
+        automatically &mdash; for example, the official Ubuntu cloud images are
         identical across all public and private clouds.
       </p>
     </div>

--- a/index.html
+++ b/index.html
@@ -176,7 +176,9 @@ layout: default
             <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/9aadcd6b-partner-logo-fujitsu.png" alt="Fujitsu logo">
         </li>
       </ul>
-      <a href="#_" class="button--primary right">See our other Ubuntu public cloud partners</a>
+      <p class="align-center">
+        <a href="http://partners.ubuntu.com/programmes/public-cloud" class="external">See our other Ubuntu public cloud partners</a>
+      </p>
 
     </div>
   </section>


### PR DESCRIPTION
## Done
- Correct cloud partner link and style
- Encode dashes as html entites
- Add deploy to `gh-pages` instructions to README

## QA
Run code, check public partners link is not broken.

